### PR TITLE
Navigate to posts from live feed

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
   return (
     <section>
       <DIDForm />
-      <LiveFeed sampleRate={0.05} displayedPosts={5} />
+      <LiveFeed sampleRate={0.01} displayedPosts={5} />
     </section>
   );
 }

--- a/src/components/live-feed/feed-item.tsx
+++ b/src/components/live-feed/feed-item.tsx
@@ -1,15 +1,18 @@
-import { AppBskyFeedPost } from "@atproto/api";
-import { Separator } from "../ui/separator";
+import Link from "next/link";
+import LinkSpan from "../link-span";
+import { JetstreamPost } from "./useJetstream";
 
 type FeedItemProps = {
-  post: AppBskyFeedPost.Record;
+  post: JetstreamPost;
 };
 
 export default function FeedItem({ post }: FeedItemProps) {
   return (
-    <div className="space-y-2">
-      <PostText text={post.text} />
-      <Separator />
+    <div className="space-y-0">
+      <PostText text={post.record.text} />
+      <Link href={`/at/${post.did}/${post.collection}/${post.rkey}`}>
+        <LinkSpan className="text-xs">See post</LinkSpan>
+      </Link>
     </div>
   );
 }

--- a/src/components/live-feed/feed.tsx
+++ b/src/components/live-feed/feed.tsx
@@ -45,9 +45,9 @@ export default function LiveFeed({
         </div>
       </div>
       <ul className="flex flex-col gap-4 py-4">
-        {posts.map(({ record, rkey }) => (
-          <li key={rkey}>
-            <FeedItem post={record} />
+        {posts.map((post) => (
+          <li key={post.rkey}>
+            <FeedItem post={post} />
           </li>
         ))}
       </ul>

--- a/src/components/live-feed/useJetstream.ts
+++ b/src/components/live-feed/useJetstream.ts
@@ -24,9 +24,12 @@ function getJetstreamUrl() {
   return jetstreamUrl;
 }
 
-type JetstreamPost = {
+export type JetstreamPost = {
   record: AppBskyFeedPost.Record;
   rkey: string;
+  cid: string;
+  did: string;
+  collection: string;
 };
 
 export function useJetstream(sampleRate: number, bufferSize: number) {
@@ -67,9 +70,7 @@ export function useJetstream(sampleRate: number, bufferSize: number) {
   return { posts, paused, togglePause };
 }
 
-function extractPost(
-  message: MessageEvent
-): { record: AppBskyFeedPost.Record; rkey: string } | undefined {
+function extractPost(message: MessageEvent): JetstreamPost | undefined {
   if (!message.data) {
     return undefined;
   }
@@ -88,5 +89,11 @@ function extractPost(
     return undefined;
   }
 
-  return { record, rkey: data.commit.rkey as string };
+  return {
+    record,
+    rkey: data.commit.rkey,
+    did: data.did,
+    cid: data.commit.cid,
+    collection: data.commit.collection,
+  };
 }


### PR DESCRIPTION
Updates the Jetstream pipeline to include more post metadata in emitted records.
This enables navigating to the page for a post from the live feed, as we can now build complete URLs to the underlying document.

