### PR TITLE
Add embedded posts in likes

### DIFF
--- a/src/app/at/[did]/[collection]/[rkey]/page.tsx
+++ b/src/app/at/[did]/[collection]/[rkey]/page.tsx
@@ -64,7 +64,7 @@ function RecordWrapper({
   }
 
   if (AppBskyFeedLike.isRecord(value)) {
-    return <BlueskyLikeRecord record={value} />;
+    return <BlueskyLikeRecord record={value} pds={pds} />;
   }
 
   if (AppBskyFeedPost.isRecord(value)) {

--- a/src/components/did-form.tsx
+++ b/src/components/did-form.tsx
@@ -25,7 +25,7 @@ export default function DIDForm() {
             type="text"
             name="did"
             defaultValue={formState.did}
-            placeholder="did:plc, did:web, or handle.bsky.social"
+            placeholder="did:plc, did:web, or Bluesky handle"
           />
           <SubmitButton />
         </div>

--- a/src/components/records/bluesky-like.tsx
+++ b/src/components/records/bluesky-like.tsx
@@ -1,11 +1,16 @@
-import { AppBskyFeedLike, AtUri } from "@atproto/api";
+import { AppBskyFeedLike, AppBskyFeedPost, AtUri } from "@atproto/api";
 import Link from "next/link";
 import LinkSpan from "../link-span";
+import { cachedFetchRecord } from "../../lib/records";
+import { Suspense, use } from "react";
+import BlueskyPostRecord from "./bluesky-post";
 
 export default function BlueskyLikeRecord({
   record,
+  pds,
 }: {
   record: AppBskyFeedLike.Record;
+  pds: string;
 }) {
   const subjectUri = new AtUri(record.subject.uri);
   return (
@@ -16,6 +21,31 @@ export default function BlueskyLikeRecord({
       >
         <LinkSpan>{subjectUri.rkey}</LinkSpan>
       </Link>
+      <Suspense fallback={<p>Loading post...</p>}>
+        <EmbeddedPost uri={subjectUri} pds={pds} />
+      </Suspense>
     </div>
   );
+}
+
+type EmbeddedPostProps = {
+  uri: AtUri;
+  pds: string;
+};
+
+function EmbeddedPost({ uri, pds }: EmbeddedPostProps) {
+  const post = use(
+    cachedFetchRecord({
+      did: uri.host,
+      collection: uri.collection,
+      rkey: uri.rkey,
+      pds,
+    })
+  );
+
+  if (!AppBskyFeedPost.isRecord(post.value)) {
+    return null;
+  }
+
+  return <BlueskyPostRecord record={post.value} />;
 }


### PR DESCRIPTION
Add embedded posts in likes. Uses `<Suspense>` to fetch a post asynchronously on the record page for Bluesky like, and renders it.

