### PR TITLE
Add embedded replies on the post record page

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@atproto/identity": "^0.4.3",
     "@atproto/oauth-client": "^0.3.1",
     "@hookform/resolvers": "^3.9.1",
+    "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-label": "^2.1.0",

--- a/src/app/at/[did]/[collection]/[rkey]/page.tsx
+++ b/src/app/at/[did]/[collection]/[rkey]/page.tsx
@@ -2,6 +2,7 @@ import BlueskyFollowRecord from "@/components/records/bluesky-follow";
 import BlueskyLikeRecord from "@/components/records/bluesky-like";
 import BlueskyPostRecord from "@/components/records/bluesky-post";
 import BlueskyProfileRecord from "@/components/records/bluesky-profile";
+import { Separator } from "@/components/ui/separator";
 import { cachedResolveDidDoc } from "@/lib/did";
 import { cachedFetchRecord, extractPDSUrl } from "@/lib/records";
 import {
@@ -41,11 +42,13 @@ export default async function RecordPage({
   }
 
   return (
-    <div className="space-y-4">
+    <div>
       <RecordWrapper value={record.value} pds={pds} did={did} />
-      <pre className="prose dark:prose-invert text-sm overflow-auto">
-        {JSON.stringify(record, null, 2)}
-      </pre>
+      <Separator className="my-4" />
+      <div className="prose dark:prose-invert w-full mt-2">
+        <h2>Record data</h2>
+        <pre>{JSON.stringify(record, null, 2)}</pre>
+      </div>
     </div>
   );
 }

--- a/src/components/records/bluesky-like.tsx
+++ b/src/components/records/bluesky-like.tsx
@@ -14,7 +14,7 @@ export default function BlueskyLikeRecord({
 }) {
   const subjectUri = new AtUri(record.subject.uri);
   return (
-    <div>
+    <div className="space-y-4">
       Liked{" "}
       <Link
         href={`/at/${subjectUri.host}/${subjectUri.collection}/${subjectUri.rkey}`}
@@ -47,5 +47,5 @@ function EmbeddedPost({ uri, pds }: EmbeddedPostProps) {
     return null;
   }
 
-  return <BlueskyPostRecord record={post.value} />;
+  return <BlueskyPostRecord record={post.value} showReplies={false} />;
 }

--- a/src/components/records/bluesky-post.tsx
+++ b/src/components/records/bluesky-post.tsx
@@ -21,8 +21,10 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
 export default function BlueskyPostRecord({
   record,
   depth = 0,
+  showReplies = true,
 }: {
   record: AppBskyFeedPost.Record;
+  showReplies?: boolean;
   depth?: number;
 }) {
   return (
@@ -36,7 +38,9 @@ export default function BlueskyPostRecord({
           {dateFormatter.format(new Date(record.createdAt))}
         </p>
       </div>
-      {record.reply?.parent && <ReplyParent record={record} depth={depth} />}
+      {showReplies && record.reply?.parent && (
+        <ReplyParent record={record} depth={depth} />
+      )}
     </div>
   );
 }

--- a/src/components/records/bluesky-post.tsx
+++ b/src/components/records/bluesky-post.tsx
@@ -1,22 +1,123 @@
-import { AppBskyFeedPost } from "@atproto/api";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { cachedResolveDidDoc } from "@/lib/did";
+import { cachedFetchRecord, extractPDSUrl } from "@/lib/records";
+import { AppBskyFeedPost, AtUri } from "@atproto/api";
+import { AccordionItem } from "@radix-ui/react-accordion";
+import { Info, Reply } from "lucide-react";
+import Link from "next/link";
+import { use } from "react";
+import LinkSpan from "../link-span";
 
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
-  dateStyle: "full",
+  dateStyle: "medium",
+  timeStyle: "short",
 });
 
 export default function BlueskyPostRecord({
   record,
+  depth = 0,
 }: {
   record: AppBskyFeedPost.Record;
+  depth?: number;
 }) {
   return (
-    <div className="prose dark:prose-invert">
-      <blockquote>
-        <p>{record.text}</p>
-      </blockquote>
-      <p className="mt-4 italic">
-        Posted on {dateFormatter.format(new Date(record.createdAt))}
-      </p>
+    <div>
+      <div className="prose dark:prose-invert">
+        <h4>Post</h4>
+        <blockquote>
+          <p>{record.text}</p>
+        </blockquote>
+        <p className="text-sm font-light">
+          {dateFormatter.format(new Date(record.createdAt))}
+        </p>
+      </div>
+      {record.reply?.parent && <ReplyParent record={record} depth={depth} />}
     </div>
+  );
+}
+
+function ReplyParent({
+  record,
+  depth,
+}: {
+  record: AppBskyFeedPost.Record;
+  depth: number;
+}) {
+  if (depth > 4 && record.reply?.parent) {
+    const { host, collection, rkey } = new AtUri(record.reply.parent.uri);
+
+    return (
+      <Alert className="my-4">
+        <AlertTitle>
+          <div className="flex flex-row items-center gap-2">
+            <Info className="h-3 w-3" />
+            More replies available
+          </div>
+        </AlertTitle>
+        <AlertDescription className="ml-5">
+          Visit the{" "}
+          <Link href={`/at/${host}/${collection}/${rkey}`}>
+            <LinkSpan>parent</LinkSpan>
+          </Link>{" "}
+          of this post to view more replies.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!record.reply?.parent) {
+    return null;
+  }
+
+  const { host, collection, rkey } = new AtUri(record.reply.parent.uri);
+  if (collection !== "app.bsky.feed.post") {
+    return null;
+  }
+
+  const didDoc = use(cachedResolveDidDoc(host));
+  if (!didDoc) {
+    return null;
+  }
+
+  const pdsUrl = extractPDSUrl(didDoc);
+  if (!pdsUrl) {
+    return null;
+  }
+
+  const post = use(
+    cachedFetchRecord({
+      did: host,
+      collection,
+      rkey,
+      pds: pdsUrl,
+    })
+  );
+
+  if (!AppBskyFeedPost.isRecord(post.value)) {
+    return null;
+  }
+
+  return (
+    <Accordion className="border-t px-4 mt-4" type="single" collapsible>
+      <AccordionItem value={post.uri}>
+        <AccordionTrigger>
+          <p className="flex flex-row items-center gap-1 text-muted-foreground">
+            <Reply className="h-3 w-3" />
+            <span>In reply to </span>
+            <Link href={`/at/${host}/${collection}/${rkey}`}>
+              <LinkSpan>{rkey}</LinkSpan>
+            </Link>
+          </p>
+        </AccordionTrigger>
+        <AccordionContent className="ml-2">
+          <BlueskyPostRecord record={post.value} depth={depth + 1} />
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   );
 }

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import * as React from "react"
+import * as AccordionPrimitive from "@radix-ui/react-accordion"
+import { ChevronDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Accordion = AccordionPrimitive.Root
+
+const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn("border-b", className)}
+    {...props}
+  />
+))
+AccordionItem.displayName = "AccordionItem"
+
+const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline text-left [&[data-state=open]>svg]:rotate-180",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
+
+const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className="overflow-hidden text-sm data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    {...props}
+  >
+    <div className={cn("pb-4 pt-0", className)}>{children}</div>
+  </AccordionPrimitive.Content>
+))
+AccordionContent.displayName = AccordionPrimitive.Content.displayName
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -55,6 +55,28 @@ export default {
   			lg: 'var(--radius)',
   			md: 'calc(var(--radius) - 2px)',
   			sm: 'calc(var(--radius) - 4px)'
+  		},
+  		keyframes: {
+  			'accordion-down': {
+  				from: {
+  					height: '0'
+  				},
+  				to: {
+  					height: 'var(--radix-accordion-content-height)'
+  				}
+  			},
+  			'accordion-up': {
+  				from: {
+  					height: 'var(--radix-accordion-content-height)'
+  				},
+  				to: {
+  					height: '0'
+  				}
+  			}
+  		},
+  		animation: {
+  			'accordion-down': 'accordion-down 0.2s ease-out',
+  			'accordion-up': 'accordion-up 0.2s ease-out'
   		}
   	}
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -734,6 +734,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-accordion@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@radix-ui/react-accordion@npm:1.2.1"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.0"
+    "@radix-ui/react-collapsible": "npm:1.1.1"
+    "@radix-ui/react-collection": "npm:1.1.0"
+    "@radix-ui/react-compose-refs": "npm:1.1.0"
+    "@radix-ui/react-context": "npm:1.1.1"
+    "@radix-ui/react-direction": "npm:1.1.0"
+    "@radix-ui/react-id": "npm:1.1.0"
+    "@radix-ui/react-primitive": "npm:2.0.0"
+    "@radix-ui/react-use-controllable-state": "npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/617678194124e90947a5ce7b9964cda406f1840c950bdaec4b759da01beb19f58b06304a973a7c1a6663da6732243f8f354504852dbda3502dd282c36035ef6f
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-arrow@npm:1.1.0":
   version: 1.1.0
   resolution: "@radix-ui/react-arrow@npm:1.1.0"
@@ -750,6 +777,32 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/cbe059dfa5a9c1677478d363bb5fd75b0c7a08221d0ac7f8e7b9aec9dbae9754f6a3518218cf63e4ed53df6c36d193c8d2618d03433a37aa0cb7ee77a60a591f
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-collapsible@npm:1.1.1":
+  version: 1.1.1
+  resolution: "@radix-ui/react-collapsible@npm:1.1.1"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.0"
+    "@radix-ui/react-compose-refs": "npm:1.1.0"
+    "@radix-ui/react-context": "npm:1.1.1"
+    "@radix-ui/react-id": "npm:1.1.0"
+    "@radix-ui/react-presence": "npm:1.1.1"
+    "@radix-ui/react-primitive": "npm:2.0.0"
+    "@radix-ui/react-use-controllable-state": "npm:1.1.0"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.0"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/e3a510c8f3a31709add35c31e3e108a2bc4db2df06e9e50cb5f25144b1cf9596b8118ad2618f851fa7c1498e057938f641a842a6770b5b7b6cd068cd2b4914f1
   languageName: node
   linkType: hard
 
@@ -1898,6 +1951,7 @@ __metadata:
     "@atproto/identity": "npm:^0.4.3"
     "@atproto/oauth-client": "npm:^0.3.1"
     "@hookform/resolvers": "npm:^3.9.1"
+    "@radix-ui/react-accordion": "npm:^1.2.1"
     "@radix-ui/react-dialog": "npm:^1.1.2"
     "@radix-ui/react-dropdown-menu": "npm:^2.1.2"
     "@radix-ui/react-label": "npm:^2.1.0"


### PR DESCRIPTION
Adds the ability to view replies to a post on the Bluesky post record page.
Uses a shadcn Accordion to render a tree of replies with a maximum depth of 5.
