### PR TITLE
Better utilise wide displays on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,13 @@ import LiveFeed from "@/components/live-feed/feed";
 
 export default function Home() {
   return (
-    <section>
-      <DIDForm />
-      <LiveFeed />
+    <section className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <div className="col-span-1 lg:col-span-1">
+        <DIDForm />
+      </div>
+      <div className="col-span-1 lg:col-span-1">
+        <LiveFeed />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
Moves the feed to the side of the DID input box on the homepage for large screens.
This looks much nicer on desktops and other big displays.
