### PR TITLE
Disable image optimisation for avatars

### DIFF
--- a/src/components/bsky-avatar.tsx
+++ b/src/components/bsky-avatar.tsx
@@ -31,6 +31,7 @@ export function BskyAvatar({
       height={100}
       src={url.toString()}
       alt="User avatar"
+      unoptimized
     />
   );
 }


### PR DESCRIPTION
This is chewing through image transformation limits on my Vercel account.

