### PR TITLE
Disable prefetching links on live feed

### DIFF
--- a/src/components/live-feed/feed-item.tsx
+++ b/src/components/live-feed/feed-item.tsx
@@ -11,7 +11,10 @@ export function FeedItem({ post }: FeedItemProps) {
   return (
     <div className="space-y-0">
       <PostText text={post.record.text} />
-      <Link href={`/at/${post.did}/${post.collection}/${post.rkey}`}>
+      <Link
+        href={`/at/${post.did}/${post.collection}/${post.rkey}`}
+        prefetch={false}
+      >
         <LinkSpan className="text-xs">See post</LinkSpan>
       </Link>
     </div>


### PR DESCRIPTION
Feed items scroll in and out of view quickly. Prefetching pages for each record is wasted bandwidth, and also burns through edge requests on Vercel.
This change should prevent the records from being prefetched.
