### PR TITLE
Disable record pre-fetching on collections page

### DIFF
--- a/src/components/records-list.tsx
+++ b/src/components/records-list.tsx
@@ -106,7 +106,7 @@ function RecordItem({ recordUri }: { recordUri: string }) {
 
   return (
     <li>
-      <Link href={browserUri}>
+      <Link href={browserUri} prefetch={false}>
         <LinkSpan>{atUri.rkey}</LinkSpan>
       </Link>
     </li>


### PR DESCRIPTION
Modifies the page that displays the list of records in a collection to not pre-fetch each record.
Part of the efforts to cut down on Vercel edge request invocations.
