### PR TITLE
Add sitemap and robots.txt

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,13 @@
+import { SITE_URL } from "@/lib/env";
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/at/",
+    },
+    sitemap: new URL("/sitemap.xml", `https://${SITE_URL}`).toString(),
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,13 @@
+import { SITE_URL } from "@/lib/env";
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const publicRoutes: string[] = ["/", "/about"];
+
+  return publicRoutes.map((route) => ({
+    url: `${SITE_URL}${route}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly",
+    priority: 0.5,
+  }));
+}


### PR DESCRIPTION
Adds `/sitemap.xml` and `/robots.txt` routes to app to improve SEO.
I have explicitly disallowed `/at/` URLs to keep bots from driving up Vercel usage.
