### PR TITLE
Stop generating records if the fetched page does not have a cursor

### DIFF
--- a/src/lib/records.ts
+++ b/src/lib/records.ts
@@ -97,8 +97,13 @@ export async function* generateRecords(
       break;
     }
 
+    yield* data.records;
+
+    if (!data.cursor) {
+      break;
+    }
+
     cursor = data.cursor;
     emitted += data.records.length;
-    yield* data.records;
   }
 }


### PR DESCRIPTION
Some PDS implementations (like [coocoon](https://github.com/haileyok/cocoon)) do not return a cursor value for `com.atproto.repo.listRecords` if there are no more pages to be fetched. Paginating through collections on such PDSs causes an infinite fetch-next loop
due to a bug in `generateRecords`.

This PR ensures that we break out of the generator early if there is no cursor returned by the PDS, which fixes this bug.
